### PR TITLE
add missing text setter for CharacterData Nodes fixes #49

### DIFF
--- a/lib/src/html/dom/node.dart
+++ b/lib/src/html/dom/node.dart
@@ -87,6 +87,11 @@ abstract class CharacterData extends Node
   }
 
   @override
+  set text(String? newValue) {
+    data = newValue;
+  }
+
+  @override
   String? get text => nodeValue;
 
   void appendData(String data) {

--- a/test/src/html/dom/node.dart
+++ b/test/src/html/dom/node.dart
@@ -285,6 +285,11 @@ void _testNode() {
       node.replaceData(2, 1, 'c');
       expect(node.nodeValue, 'abcde');
     });
+    test('text', () {
+      final node = Comment('awert');
+      node.text = 'abXde';
+      expect(node.text, 'abXde');
+    });
   });
 
   group('Comment', () {
@@ -313,6 +318,11 @@ void _testNode() {
     test('toString()', () {
       final node = Text('abc');
       expect(node.toString(), 'abc');
+    });
+    test('text', () {
+      final node = Text('abc');
+      node.text = 'hjkyu';
+      expect(node.nodeValue, 'hjkyu');
     });
   });
 }


### PR DESCRIPTION
Allow setting `CharacterData.text` on VM.

I ran into this issue while trying to set the text of a `Text` node on VM.

closes #49 