### PR TITLE
Don't use direct conditional exports for sdk libraries

### DIFF
--- a/lib/html.dart
+++ b/lib/html.dart
@@ -33,11 +33,11 @@
 /// For information on writing web apps with Dart, see https://webdev.dartlang.org.
 library universal_html;
 
-export 'dart:html'
-    if (dart.library.html) 'dart:html' // Browser
+export 'src/_sdk/html.dart'
+    if (dart.library.html) 'src/_sdk/html.dart' // Browser
     if (dart.library.io) 'src/html.dart' // VM
     if (dart.library.js) 'src/html.dart'; // Node.JS
-export 'dart:html'
-    if (dart.library.html) 'dart:html' // Browser
+export 'src/_sdk/html.dart'
+    if (dart.library.html) 'src/_sdk/html.dart' // Browser
     if (dart.library.io) 'src/html_top_level_functions.dart' // VM
     if (dart.library.js) 'src/html_top_level_functions.dart'; // Node.JS

--- a/lib/indexed_db.dart
+++ b/lib/indexed_db.dart
@@ -14,7 +14,7 @@
 
 library universal_html.indexed_db;
 
-export 'dart:indexed_db'
-    if (dart.library.indexed_db) 'dart:indexed_db' // Browser
+export 'src/_sdk/indexed_db.dart'
+    if (dart.library.indexed_db) 'src/_sdk/indexed_db.dart' // Browser
     if (dart.library.io) 'src/indexed_db.dart' // VM
     if (dart.library.js) 'src/indexed_db.dart'; // Node.JS

--- a/lib/js.dart
+++ b/lib/js.dart
@@ -14,6 +14,6 @@
 
 library universal_html.js;
 
-export 'dart:js'
-    if (dart.library.js) 'dart:js' // Browser, Node.JS
+export 'src/_sdk/js.dart'
+    if (dart.library.js) 'src/_sdk/js.dart' // Browser, Node.JS
     if (dart.library.io) 'src/js.dart'; // VM

--- a/lib/js_util.dart
+++ b/lib/js_util.dart
@@ -14,6 +14,6 @@
 
 library universal_html.js_util;
 
-export 'dart:js_util'
-    if (dart.library.js_util) 'dart:js_util' // Browser, Node.JS
+export 'src/_sdk/js_util.dart'
+    if (dart.library.js_util) 'src/_sdk/js_util.dart' // Browser, Node.JS
     if (dart.library.io) 'src/js_util.dart'; // VM

--- a/lib/svg.dart
+++ b/lib/svg.dart
@@ -14,7 +14,7 @@
 
 library universal_html.svg;
 
-export 'dart:svg'
-    if (dart.library.svg) 'dart:svg' // Browser
+export 'src/_sdk/svg.dart'
+    if (dart.library.svg) 'src/_sdk/svg.dart' // Browser
     if (dart.library.io) 'src/svg.dart' // VM
     if (dart.library.js) 'src/svg.dart'; // Node.JS

--- a/lib/web_audio.dart
+++ b/lib/web_audio.dart
@@ -14,7 +14,7 @@
 
 library universal_html.web_audio;
 
-export 'dart:web_audio'
-    if (dart.library.web_audio) 'dart:web_audio' // Browser
+export 'src/_sdk/web_audio.dart'
+    if (dart.library.web_audio) 'src/_sdk/web_audio.dart' // Browser
     if (dart.library.io) 'src/web_audio.dart' // VM
     if (dart.library.js) 'src/web_audio.dart'; // Node.JS

--- a/lib/web_gl.dart
+++ b/lib/web_gl.dart
@@ -14,7 +14,7 @@
 
 library universal_html.web_gl;
 
-export 'dart:web_gl'
-    if (dart.library.web_gl) 'dart:web_gl' // Browser
+export 'src/_sdk/web_gl.dart'
+    if (dart.library.web_gl) 'src/_sdk/web_gl.dart' // Browser
     if (dart.library.io) 'src/web_gl.dart' // VM
     if (dart.library.js) 'src/web_gl.dart'; // Node.JS


### PR DESCRIPTION
Fixes https://github.com/dint-dev/universal_html/issues/48.

Hi, i was having the same issue and this changes fixed it for me, more info in https://github.com/dart-lang/build/issues/3173. You already had the `src/_sdk` directory with all `dart:<library>`, so I exported those instead of directly exporting the dart sdk libraries.

Please let me know if there is anything more I can do.
Thanks for your work!