### PR TITLE
Update element_subclasses.dart

### DIFF
--- a/lib/src/html/dom/element_subclasses.dart
+++ b/lib/src/html/dom/element_subclasses.dart
@@ -2749,7 +2749,7 @@ class StyleElement extends HtmlElement {
       return null;
     }
     final text = this.text;
-    final parsed = css.parse(text);
+    final parsed = css.parse(text as String);
     final styleSheet = CssStyleSheet.constructor();
     for (var node in parsed.topLevels) {
       if (node is css.RuleSet) {


### PR DESCRIPTION
The argument type 'String?' can't be assigned to the parameter type 'Object' because 'String?' is nullable and 'Object' isn't.

To fix this, we need to change the argument type to 'String'. 

This will tell the compiler that the argument is a non-nullable string, and the error will be resolved.

Here are some additional details about the error:
- The argument type 'String?' is a nullable string. This means that it can either be a string or null.
- The parameter type 'Object' is a non-nullable object. This means that it can only be an object.
- The compiler is trying to assign the argument 'text' to the parameter 'css', but the argument type is not compatible with the parameter type.
- To fix this, we need to change the argument type to 'String'. This will tell the compiler that the argument is a non-nullable string, and the error will be resolved.