### PR TITLE
Update Line no. 2752 with null check. element_subclasses.dart

### DIFF
--- a/lib/src/html/dom/element_subclasses.dart
+++ b/lib/src/html/dom/element_subclasses.dart
@@ -2749,7 +2749,7 @@ class StyleElement extends HtmlElement {
       return null;
     }
     final text = this.text;
-    final parsed = css.parse(text);
+    final parsed = css.parse(text??'');
     final styleSheet = CssStyleSheet.constructor();
     for (var node in parsed.topLevels) {
       if (node is css.RuleSet) {


### PR DESCRIPTION
Added a null check at line no. 2752. Because it was throwing a compile time exception when used in a project.  After doing this change it worked fine [Locally].