### PR TITLE
Add "target" getter and setter to AreaElement

### DIFF
--- a/lib/src/html/dom/element_subclasses.dart
+++ b/lib/src/html/dom/element_subclasses.dart
@@ -114,6 +114,12 @@ class AreaElement extends HtmlElement
   set rel(String value) {
     _setAttribute('rel', value);
   }
+  
+  String? get target => _getAttribute('target');
+
+  set target(String? value) {
+    _setAttribute('target', value);
+  }
 
   @override
   Element _newInstance(Document ownerDocument) => AreaElement._(ownerDocument);


### PR DESCRIPTION
Adds missing "target" getter and setter to AreaElement

https://api.dart.dev/stable/3.1.0/dart-html/AreaElement/target.html
