### PR TITLE
Fixes types nullability for compatibility with dart:html APIs:

### DIFF
--- a/lib/src/html/api/event_subclasses.dart
+++ b/lib/src/html/api/event_subclasses.dart
@@ -772,6 +772,8 @@ class Touch {
   final int radiusX;
   final int radiusY;
 
+  Point get page => Point(radiusX, radiusY);
+
   Touch({
     this.radiusX = 0,
     this.radiusY = 0,

--- a/lib/src/html/api/history.dart
+++ b/lib/src/html/api/history.dart
@@ -242,9 +242,9 @@ mixin _UrlBase {
     return '$scheme:';
   }
 
-  String get search => _uri?.query ?? '';
+  String? get search => _uri?.query;
 
-  set search(String value) {
+  set search(String? value) {
     throw UnimplementedError();
   }
 

--- a/lib/src/html/api/http_request.dart
+++ b/lib/src/html/api/http_request.dart
@@ -275,7 +275,7 @@ class HttpRequest extends HttpRequestEventTarget {
   Map<String, String>? get responseHeaders => _responseHeaders;
 
   /// The response in String form or empty String on failure.
-  String get responseText {
+  String? get responseText {
     final responseData = _responseData;
     if (responseData == null) {
       return '';
@@ -291,7 +291,7 @@ class HttpRequest extends HttpRequestEventTarget {
   /// `text/xml` stream, unless responseType = 'document' and the request is
   /// synchronous.
   Document get responseXml =>
-      DomParser().parseFromString(responseText, 'text/xml');
+      DomParser().parseFromString(responseText ?? '', 'text/xml');
 
   /// The HTTP result code from the request (200, 404, etc).
   /// See also: [HTTP Status Codes](http://en.wikipedia.org/wiki/List_of_HTTP_status_codes)
@@ -560,7 +560,7 @@ class HttpRequest extends HttpRequestEventTarget {
       url,
       withCredentials: withCredentials,
       onProgress: onProgress,
-    ).then((HttpRequest xhr) => xhr.responseText);
+    ).then((HttpRequest xhr) => xhr.responseText ?? '');
   }
 
   /// Makes a server POST request with the specified data encoded as form data.
@@ -749,7 +749,7 @@ class HttpRequest extends HttpRequestEventTarget {
   }
 }
 
-class HttpRequestEventTarget extends EventTarget {
+class HttpRequestEventTarget extends EventTarget implements HttpRequestUpload {
   /// Static factory designed to expose `abort` events to event
   /// handlers that are not necessarily instances of [HttpRequestEventTarget].
   ///
@@ -821,8 +821,17 @@ class HttpRequestEventTarget extends EventTarget {
 
   /// Stream of `timeout` events handled by this [HttpRequestEventTarget].
   Stream<ProgressEvent> get onTimeout => timeoutEvent.forTarget(this);
+
 }
 
 abstract class HttpRequestUpload {
   HttpRequestUpload._();
+
+  Stream<ProgressEvent> get onAbort;
+  Stream<ProgressEvent> get onError;
+  Stream<ProgressEvent> get onLoad;
+  Stream<ProgressEvent> get onLoadEnd;
+  Stream<ProgressEvent> get onLoadStart;
+  Stream<ProgressEvent> get onProgress;
+  Stream<ProgressEvent> get onTimeout;
 }

--- a/lib/src/html/api/workers.dart
+++ b/lib/src/html/api/workers.dart
@@ -201,7 +201,7 @@ class FormData {
 
   void delete(String name) => throw UnimplementedError();
 
-  Object get(String name) => throw UnimplementedError();
+  Object? get(String name) => throw UnimplementedError();
 
   List<Object> getAll(String name) => throw UnimplementedError();
 

--- a/lib/src/html/dom/element.dart
+++ b/lib/src/html/dom/element.dart
@@ -993,7 +993,7 @@ abstract class Element extends Node
     classSet.addAll(value);
   }
 
-  String? get className => _getAttribute('class');
+  String get className => _getAttribute('class') ?? '';
 
   set className(String? newValue) {
     _setAttribute('class', newValue);

--- a/lib/src/html/dom/element_subclasses.dart
+++ b/lib/src/html/dom/element_subclasses.dart
@@ -2601,7 +2601,7 @@ class SelectElement extends HtmlElement
 
   ValidityState get validity => ValidityState.constructor();
 
-  String get value {
+  String? get value {
     final options = this.options;
     for (var option in options) {
       if (option.selected ?? false) {
@@ -2614,7 +2614,7 @@ class SelectElement extends HtmlElement
     return options.first.value;
   }
 
-  set value(String value) {
+  set value(String? value) {
     for (var option in options) {
       option.selected = option.value == value;
     }
@@ -3162,7 +3162,7 @@ class TextAreaElement extends HtmlElement
     _setAttributeInt('rows', value);
   }
 
-  int get textLength => value.length;
+  int? get textLength => value?.length;
 
   String? get type => null;
 
@@ -3170,10 +3170,10 @@ class TextAreaElement extends HtmlElement
 
   ValidityState get validity => ValidityState.constructor();
 
-  String get value => text ?? '';
+  String? get value => text;
 
-  set value(String value) {
-    text = value.replaceAll('\n', '');
+  set value(String? value) {
+    text = value?.replaceAll('\n', '');
   }
 
   bool get willValidate {
@@ -3198,7 +3198,7 @@ class TextAreaElement extends HtmlElement
   }
 
   void select() {
-    setSelectionRange(0, textLength);
+    setSelectionRange(0, textLength ?? 0);
   }
 
   void setCustomValidity(String error) {}

--- a/lib/src/html/dom/shared_with_dart2js/css_class_set.dart
+++ b/lib/src/html/dom/shared_with_dart2js/css_class_set.dart
@@ -416,7 +416,7 @@ class _ElementCssClassSet extends _CssClassSetImpl {
   @override
   Set<String> readClasses() {
     var s = <String>{};
-    var classname = _element.className!;
+    var classname = _element.className;
 
     for (final name in classname.split(' ')) {
       final trimmed = name.trim();


### PR DESCRIPTION
Seems that nullability of those fields changed before dart 2.17 so I think those can be safely updated as this library targets sdk >=2.17.0


set Location.search to nullable
https://api.dart.dev/stable/2.17.0/dart-html/Location/search.html

set HttpRequest.responseText to nullable
https://api.dart.dev/stable/2.17.0/dart-html/HttpRequest/responseText.html

added HttpRequestUpload interface events
https://api.dart.dev/stable/2.17.0/dart-html/HttpRequestUpload-class.html

set FormData.get return to nullable
https://api.dart.dev/stable/2.17.0/dart-html/FormData/get.html

set Element.className to non nullable
https://api.dart.dev/stable/2.17.0/dart-html/Element/className.html

set SelectElement.value to nullable
https://api.dart.dev/stable/2.17.0/dart-html/SelectElement/value.html

set TextAreaElement.textLength and TextAreaElement.value to nullable
https://api.dart.dev/stable/2.17.0/dart-html/TextAreaElement-class.html

added Touch.page
https://api.dart.dev/stable/2.17.0/dart-html/Touch-class.html