### PR TITLE
HttpRequest load fix

### DIFF
--- a/lib/src/html/api/http_request.dart
+++ b/lib/src/html/api/http_request.dart
@@ -517,6 +517,7 @@ class HttpRequest extends HttpRequestEventTarget {
 
       // Set response data
       _responseData = Uint8List.fromList(buffer);
+      dispatchEvent(ProgressEvent('load'));
     } catch (error) {
       dispatchEvent(ProgressEvent('error'));
     } finally {

--- a/test/src/html/api/networking_http_request.dart
+++ b/test/src/html/api/networking_http_request.dart
@@ -125,6 +125,11 @@ void _testHttpRequest() {
       expect(onTimeout.eventsDispatched, 0);
     }, timeout: Timeout(Duration(seconds: 5)));
 
+    test('GET, using getString', () async {
+      String testResponse = await HttpRequest.getString('http://localhost:$_httpServerPort/http_request/ok');
+      expect(testResponse, 'hello');
+    }, timeout: Timeout(Duration(seconds: 5)));
+
     test('Failing request', () async {
       //
       // Declare HttpRequest


### PR DESCRIPTION
Because this event was missing, using HttpRequest with onLoad listener was not working as listener was never called:
```
    var xhr = HttpRequest();
    xhr.open('GET', 'https://swift.shop', async: true);
    xhr.onLoad.listen((e) {
      print('LOADED');
    });
    xhr.send();
```

This event was also used internally in `request` method so methods like `getString` were not working as well:

```
    HttpRequest.getString('https://github.com').then((content) {
      print(content);
    });
```

I think that this is a correct moment to send this event according to specs.
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/load_event


I have added a test for getString method that fails without this fix.



