### PR TITLE
fix replaceWith bugfix for node argument that is already in document tree

### DIFF
--- a/lib/src/html/dom/node.dart
+++ b/lib/src/html/dom/node.dart
@@ -386,19 +386,6 @@ abstract class Node extends EventTarget {
     return sb.toString();
   }
 
-  void remove() {
-    final parent = _parent;
-    if (parent == null) {
-      return;
-    }
-
-    // Mark node as dirty
-    _markDirty();
-    _removeFromTree(null);
-    parent._mutated();
-    _mutated();
-  }
-
   void _removeFromTree(Node? replaceWith) {
     final parent = _parent;
     if (parent == null) {
@@ -438,12 +425,16 @@ abstract class Node extends EventTarget {
     _nextNode = null;
   }
 
-  void replaceWith(Node node) {
+  void remove() {
     final parent = _parent;
-    if (parent == null) {
-      return;
-    }
+    // Mark node as dirty
+    _markDirty();
+    _removeFromTree(null);
+    parent?._mutated();
+    _mutated();
+  }
 
+  void replaceWith(Node node) {
     // Mark nodes as dirty
     _markDirty();
     node._markDirty();

--- a/test/src/html/dom/node.dart
+++ b/test/src/html/dom/node.dart
@@ -37,7 +37,11 @@ void _testNode() {
     test('replaceWith', () {
       final e0 = Element.tag('e0')..appendText('e0-text');
       final e1 = Element.tag('e1')..appendText('e1-text');
-      final e2 = Element.tag('e2')..appendText('e2-text');
+      final e2 = Element.tag('e2')..append(
+          Element.tag('e2c1')
+      )..append(
+          Element.tag('e2c2')
+      );
       final root = Element.tag('sometag')
         ..setAttribute('k', 'v')
         ..append(e0)
@@ -48,7 +52,7 @@ void _testNode() {
       expect(
           root.outerHtml,
           equals(
-              '<sometag k="v"><e0>e0-text</e0><e1>e1-text</e1><e2>e2-text</e2></sometag>'));
+              '<sometag k="v"><e0>e0-text</e0><e1>e1-text</e1><e2><e2c1></e2c1><e2c2></e2c2></e2></sometag>'));
 
       // Replace child #1 of 'e1'
       {
@@ -64,7 +68,7 @@ void _testNode() {
         expect(
             root.outerHtml,
             equals(
-                '<sometag k="v"><e0>e0-text</e0><e1>e1-text-replaced</e1><e2>e2-text</e2></sometag>'));
+                '<sometag k="v"><e0>e0-text</e0><e1>e1-text-replaced</e1><e2><e2c1></e2c1><e2c2></e2c2></e2></sometag>'));
       }
 
       // Replace child #2 of root ('e1')
@@ -83,7 +87,23 @@ void _testNode() {
         expect(
             root.outerHtml,
             equals(
-                '<sometag k="v"><e0>e0-text</e0>e1-replaced<e2>e2-text</e2></sometag>'));
+                '<sometag k="v"><e0>e0-text</e0>e1-replaced<e2><e2c1></e2c1><e2c2></e2c2></e2></sometag>'));
+      }
+      // Replace with existing node to check if it moved properly
+      {
+        final replacement = e2.children.first;
+        e0.replaceWith(replacement);
+
+        expect(e0.nextNode, isNull);
+        expect(e0.previousNode, isNull);
+        expect(e0.parent, isNull);
+        expect(replacement.parent, same(root));
+        expect(replacement.previousNode, isNull);
+        expect(replacement.nextNode, isNotNull);
+        expect(
+          root.outerHtml,
+          equals(
+            '<sometag k="v"><e2c1></e2c1>e1-replaced<e2><e2c2></e2c2></e2></sometag>'));
       }
     });
     test('replaceWith when the node has no parent', () {


### PR DESCRIPTION
Current implementation of `replaceWith` is missing setting `_nextNode` and `_previousNode` for siblings of the node argument (the one that replaces current node).

It is causing tree structure issues and bugs when `replaceWith` is called with an argument that is already in the same document tree (added test for it).

Cant find this documented but Dart and JS DOM versions of this method are simply moving the replacing element from the current location so guess this should work same way.

Refactored a little bit to avoid logic repetition.
 