### PR TITLE
set HttpRequest::responseHeaders to non nullable

### DIFF
--- a/lib/src/html/api/http_request.dart
+++ b/lib/src/html/api/http_request.dart
@@ -272,7 +272,7 @@ class HttpRequest extends HttpRequestEventTarget {
   /// separated by a comma and a space.
   ///
   /// See: http://www.w3.org/TR/XMLHttpRequest/#the-getresponseheader()-method
-  Map<String, String>? get responseHeaders => _responseHeaders;
+  Map<String, String> get responseHeaders => _responseHeaders;
 
   /// The response in String form or empty String on failure.
   String? get responseText {


### PR DESCRIPTION
Set getter to non nullable to match api:

https://api.dart.dev/stable/2.17.0/dart-html/HttpRequest/responseHeaders.html