### PR TITLE
fix: BroadcastChannel method not found when run on `dart.library.io`

### DIFF
--- a/example/example.dart
+++ b/example/example.dart
@@ -14,4 +14,9 @@ void main() {
   // Do a CSS query
   print(divElement.querySelector('div > .greeting')!.text);
   // --> Hello world
+
+  final broadcastChannel = BroadcastChannel('Channel_Name');
+  broadcastChannel.onMessage.listen((event) {
+    print(event);
+  });
 }

--- a/lib/src/html.dart
+++ b/lib/src/html.dart
@@ -87,6 +87,7 @@ part 'html/api/web_socket.dart';
 part 'html/api/window.dart';
 part 'html/api/window_misc.dart';
 part 'html/api/workers.dart';
+part 'html/api/broadcast_channel.dart';
 part 'html/dom/css.dart';
 part 'html/dom/css_computed_style.dart';
 part 'html/dom/css_rect.dart';

--- a/lib/src/html/api/broadcast_channel.dart
+++ b/lib/src/html/api/broadcast_channel.dart
@@ -1,0 +1,13 @@
+part of universal_html.internal;
+
+class BroadcastChannel {
+  final String name;
+
+  BroadcastChannel(this.name);
+
+  void close() {}
+
+  void postMessage(Object message) {}
+
+  Stream<dynamic> get onMessage => const Stream.empty();
+}


### PR DESCRIPTION
## Desc

We get `Method not found: BroadcastChannel` error when calling BroadcastChannel and running it on mobile